### PR TITLE
store private state for extension in x_reducer instance variable

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,10 @@ For a detailed view of what has changed, refer to the {url-repo}/commits/main[co
 * Register `Asciidoctor::Reducer::IncludeMapper` extension when `asciidoctor/reducer/include_mapper` is required (#26)
 * Add `Asciidoctor::Reducer::Extensions.key` method that returns key for registering extension group
 
+=== Changed
+
+* Rename x_include_replacements attr on reader to include_replacements since it's public
+
 === Fixed
 
 * Replace remote include with link if `allow-uri-read` attribute is not set

--- a/lib/asciidoctor/reducer/conditional_directive_tracker.rb
+++ b/lib/asciidoctor/reducer/conditional_directive_tracker.rb
@@ -8,7 +8,7 @@ module Asciidoctor::Reducer
       cond_lineno = @lineno
       result = super
       return result if @skipping && skip_active
-      drop = @x_include_replacements.current[:drop] ||= []
+      drop = @include_replacements.current[:drop] ||= []
       if (depth_change = @conditional_stack.size - depth) < 0
         if skip_active
           drop.push(*(drop.pop..cond_lineno))

--- a/lib/asciidoctor/reducer/include_directive_tracker.rb
+++ b/lib/asciidoctor/reducer/include_directive_tracker.rb
@@ -2,21 +2,20 @@
 
 module Asciidoctor::Reducer
   module IncludeDirectiveTracker
+    attr_reader :include_replacements
     attr_writer :source_lines
-    attr_reader :x_include_replacements
 
     def self.extended instance
-      instance.instance_variable_set :@x_include_replacements, ([{}].extend CurrentPosition)
-      instance.instance_variable_set :@x_include_directive_line, nil
-      instance.instance_variable_set :@x_include_pushed, nil
+      instance.instance_variable_set :@include_replacements, ([{}].extend CurrentPosition)
+      instance.instance_variable_set :@x_reducer, {}
     end
 
     def preprocess_include_directive target, attrlist
-      @x_include_directive_line = %(include::#{target}[#{attrlist}])
-      @x_include_pushed = false
+      @x_reducer[:include_directive_line] = %(include::#{target}[#{attrlist}])
+      @x_reducer[:include_pushed] = false
       inc_lineno = @lineno # we're currently on the include line, which is 1-based
       result = super
-      unless @x_include_pushed
+      unless @x_reducer[:include_pushed]
         if (ln = peek_line true) && (ln.end_with? ']') && !(unresolved = ln.start_with? 'Unresolved directive in ')
           if inc_lineno == @lineno && (unresolved = ln.start_with? 'link:')
             ln = %(#{ln.slice 0, (ln.length - 1)}role=include])
@@ -24,12 +23,12 @@ module Asciidoctor::Reducer
         end
         push_include_replacement inc_lineno, (unresolved ? [ln] : []), unresolved
       end
-      @x_include_directive_line = @x_include_pushed = nil
+      @x_reducer.clear
       result
     end
 
     def push_include data, file, path, lineno, attrs
-      @x_include_pushed = true
+      @x_reducer[:include_pushed] = true
       inc_lineno = @lineno - 1 # we're below the include line, which is 1-based
       prev_inc_depth = @include_stack.size
       result = super
@@ -38,17 +37,17 @@ module Asciidoctor::Reducer
     end
 
     def pop_include
-      @x_include_replacements.up unless @x_include_pushed
+      @include_replacements.up unless @x_reducer[:include_pushed]
       super
     end
 
     private
 
     def push_include_replacement lineno, lines, unresolved = false
-      (inc_replacements = @x_include_replacements) << {
+      (inc_replacements = @include_replacements) << {
         into: inc_replacements.pointer,
         lineno: lineno,
-        line: @x_include_directive_line,
+        line: @x_reducer[:include_directive_line],
         lines: lines,
       }
       inc_replacements.to_end unless unresolved || lines.empty?

--- a/lib/asciidoctor/reducer/tree_processor.rb
+++ b/lib/asciidoctor/reducer/tree_processor.rb
@@ -3,7 +3,7 @@
 module Asciidoctor::Reducer
   class TreeProcessor < ::Asciidoctor::Extensions::TreeProcessor
     def process doc
-      if (inc_replacements = doc.reader.x_include_replacements).size > 1 || !(inc_replacements[0][:drop] || []).empty?
+      if (inc_replacements = doc.reader.include_replacements).size > 1 || !(inc_replacements[0][:drop] || []).empty?
         inc_replacements[0][:lines] = doc.source_lines.dup
         inc_replacements.reverse_each do |it|
           if (into = it[:into])

--- a/spec/reducer_spec.rb
+++ b/spec/reducer_spec.rb
@@ -715,7 +715,7 @@ describe Asciidoctor::Reducer do
         prefer
         process do |interim_doc|
           unless interim_doc.options[:reduced]
-            interim_doc.reader.x_include_replacements[1][:line] = 'include::not-a-match[]'
+            interim_doc.reader.include_replacements[1][:line] = 'include::not-a-match[]'
           end
           nil
         end


### PR DESCRIPTION
* store private state for extension in x_reducer instance variable
* rename x_include_replacements to include_replacements since its a public attr